### PR TITLE
refactor(rpc): move `rpc` to `runtime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ impl Node for Handler {
 
                 if !runtime.is_from_cluster(&req.src) {
                     for node in runtime.neighbours() {
-                        runtime.spawn(rpc(runtime.clone(), node.clone(), msg.clone()));
+                        runtime.spawn(runtime.rpc(node.clone(), msg.clone()));
                     }
                 }
 
@@ -278,7 +278,7 @@ fn handler(runtime: Runtime) -> Handler {
 ```rust
 use async_trait::async_trait;
 use maelstrom::protocol::Message;
-use maelstrom::{Node, Result, Runtime, rpc};
+use maelstrom::{Node, Result, Runtime};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
@@ -289,14 +289,14 @@ struct Handler {}
 impl Node for Handler {
     async fn process(&self, runtime: Runtime, req: Message) -> Result<()> {
         // 1.
-        runtime.spawn(rpc(runtime.clone(), node.clone(), msg.clone()));
+        runtime.spawn(runtime.rpc(node.clone(), msg.clone()));
         
         // 2. put it into runtime.spawn(async move { ... }) if needed
-        let res: RPCResult = rpc(runtime.clone(), node.clone(), msg.clone()).await?;
+        let res: RPCResult = runtime.rpc(node.clone(), msg.clone()).await?;
         let _msg: Result<Message> = res.await;
         
         // 3. put it into runtime.spawn(async move { ... }) if needed
-        let mut res: RPCResult = rpc(runtime.clone(), node.clone(), msg.clone()).await?;
+        let mut res: RPCResult = runtime.rpc(node.clone(), msg.clone()).await?;
         let (mut ctx, _handler) = Context::with_timeout(Duration::from_secs(1));
         let _msg: Message = res.done_with(ctx).await?;
         

--- a/examples/broadcast.rs
+++ b/examples/broadcast.rs
@@ -5,7 +5,7 @@
 use async_trait::async_trait;
 use log::info;
 use maelstrom::protocol::{Message, MessageBody};
-use maelstrom::{done, rpc, Node, Result, Runtime};
+use maelstrom::{done, Node, Result, Runtime};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
@@ -39,7 +39,7 @@ impl Node for Handler {
 
                 if !runtime.is_from_cluster(&req.src) {
                     for node in runtime.neighbours() {
-                        runtime.spawn(rpc(runtime.clone(), node.clone(), msg.clone()));
+                        runtime.spawn(runtime.rpc(node.clone(), msg.clone()));
                     }
                 }
 

--- a/examples/broadcast_sync.rs
+++ b/examples/broadcast_sync.rs
@@ -5,7 +5,7 @@
 use async_trait::async_trait;
 use log::info;
 use maelstrom::protocol::{Message, MessageBody};
-use maelstrom::{done, rpc, Node, Result, Runtime};
+use maelstrom::{done, Node, Result, Runtime};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 
@@ -39,7 +39,7 @@ impl Node for Handler {
 
                 if !runtime.is_from_cluster(&req.src) {
                     for node in runtime.neighbours() {
-                        let _ = rpc(runtime.clone(), node.clone(), msg.clone())
+                        let _ = runtime.rpc(node.clone(), msg.clone())
                             .await? // Result<RPCResult>
                             .await?; // Result<Message>
                     }

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, rpc, Runtime};
+use crate::{Error, Result, Runtime};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -78,7 +78,7 @@ impl KV for Storage {
         T: Deserialize<'static> + Send,
     {
         let req = Message::Read::<String> { key };
-        let mut call = rpc(self.runtime.clone(), self.typ.to_string(), req).await?;
+        let mut call = self.runtime.rpc(self.typ.to_string(), req).await?;
         let msg = call.done_with(ctx).await?;
         let data = msg.body.as_obj::<Message<T>>()?;
         match data {
@@ -95,7 +95,8 @@ impl KV for Storage {
         T: Serialize + Send,
     {
         let req = Message::Write::<T> { key, value };
-        let mut call = rpc(self.runtime.clone(), self.typ.to_string(), req).await?;
+
+        let mut call = self.runtime.rpc(self.typ.to_string(), req).await?;
         let _msg = call.done_with(ctx).await?;
         Ok(())
     }
@@ -105,7 +106,7 @@ impl KV for Storage {
         T: Serialize + Deserialize<'static> + Send,
     {
         let req = Message::Cas::<T> { key, from, to, put };
-        let mut call = rpc(self.runtime.clone(), self.typ.to_string(), req).await?;
+        let mut call = self.runtime.rpc( self.typ.to_string(), req).await?;
         let _msg = call.done_with(ctx).await?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(async_closure)]
-
-extern crate core;
-
 pub(crate) mod error;
 pub mod kv;
 pub mod log;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,13 +2,12 @@ use crate::protocol::{ErrorMessageBody, Message};
 use crate::Error;
 use crate::Result;
 use crate::Runtime;
-use serde::Serialize;
 use std::future::Future;
 use std::pin::{pin, Pin};
 use std::task::Poll;
 use tokio::select;
 use tokio::sync::oneshot::Receiver;
-use tokio::sync::{oneshot, OnceCell};
+use tokio::sync::{OnceCell};
 use tokio_context::context::Context;
 
 /// Represents a result of a RPC call. Can be awaited with or without timeout.
@@ -17,7 +16,7 @@ use tokio_context::context::Context;
 ///
 /// ```
 /// use maelstrom::protocol::Message;
-/// use maelstrom::{RPCResult, Runtime, Result, rpc};
+/// use maelstrom::{RPCResult, Runtime, Result};
 /// use serde::Serialize;
 /// use tokio_context::context::Context;
 ///
@@ -25,7 +24,7 @@ use tokio_context::context::Context;
 /// where
 ///     T: Serialize,
 /// {
-///     let mut res: RPCResult = rpc(runtime, node, msg).await?;
+///     let mut res: RPCResult = runtime.rpc(node, msg).await?;
 ///     return res.done_with(ctx).await;
 /// }
 /// ```
@@ -50,14 +49,14 @@ impl RPCResult {
     ///
     /// ```
     /// use maelstrom::protocol::Message;
-    /// use maelstrom::{RPCResult, Runtime, Result, rpc};
+    /// use maelstrom::{RPCResult, Runtime, Result};
     /// use serde::Serialize;
     ///
     /// async fn call<T>(runtime: Runtime, node: String, msg: T)
     /// where
     ///     T: Serialize,
     /// {
-    ///     let _ = rpc(runtime, node, msg).await;
+    ///     let _ = runtime.rpc(node, msg).await;
     /// }
     /// ```
     pub fn done(&mut self) {
@@ -71,7 +70,7 @@ impl RPCResult {
     ///
     /// ```
     /// use maelstrom::protocol::Message;
-    /// use maelstrom::{RPCResult, Runtime, Result, rpc};
+    /// use maelstrom::{RPCResult, Runtime, Result};
     /// use serde::Serialize;
     /// use tokio_context::context::Context;
     ///
@@ -79,7 +78,7 @@ impl RPCResult {
     /// where
     ///     T: Serialize,
     /// {
-    ///     let mut res: RPCResult = rpc(runtime, node, msg).await?;
+    ///     let mut res: RPCResult = runtime.rpc(node, msg).await?;
     ///     return res.done_with(ctx).await;
     /// }
     /// ```
@@ -116,14 +115,14 @@ impl Drop for RPCResult {
 ///
 /// ```
 /// use maelstrom::protocol::Message;
-/// use maelstrom::{RPCResult, Runtime, Result, rpc};
+/// use maelstrom::{RPCResult, Runtime, Result};
 /// use serde::Serialize;
 ///
 /// async fn call<T>(runtime: Runtime, node: String, msg: T) -> Result<Message>
 /// where
 ///     T: Serialize,
 /// {
-///     let mut res: RPCResult = rpc(runtime, node, msg).await?;
+///     let mut res: RPCResult = runtime.rpc(node, msg).await?;
 ///     return res.await;
 /// }
 /// ```
@@ -147,70 +146,6 @@ impl Future for RPCResult {
             _ => Poll::Pending,
         }
     }
-}
-
-/// Example:
-/// ```
-/// use maelstrom::{Error, Result, rpc, Runtime};
-/// use std::fmt::{Display, Formatter};
-/// use serde::Serialize;
-/// use serde::Deserialize;
-/// use tokio_context::context::Context;
-///
-/// pub struct Storage {
-///     typ: &'static str,
-///     runtime: Runtime,
-/// }
-///
-/// impl Storage {
-///     async fn get<T>(&self, ctx: Context, key: String) -> Result<T>
-///         where
-///             T: Deserialize<'static> + Send,
-///     {
-///         let req = Message::Read::<String> { key };
-///         let mut call = rpc(self.runtime.clone(), self.typ.to_string(), req).await?;
-///         let msg = call.done_with(ctx).await?;
-///         let data = msg.body.as_obj::<Message<T>>()?;
-///         match data {
-///             Message::ReadOk { value } => Ok(value),
-///             _ => Err(Box::new(Error::Custom(
-///                 -1,
-///                 "kv: protocol violated".to_string(),
-///             ))),
-///         }
-///     }
-/// }
-///
-/// #[derive(Serialize, Deserialize)]
-/// #[serde(rename_all = "snake_case", tag = "type")]
-/// enum Message<T> {
-///     Read {
-///         key: String,
-///     },
-///     ReadOk {
-///         value: T,
-///     },
-/// }
-/// ```
-pub async fn rpc<T>(runtime: Runtime, to: String, request: T) -> Result<RPCResult>
-where
-    T: Serialize,
-{
-    let mut msg = crate::protocol::message(runtime.node_id().to_string(), to, request)?;
-    let req_msg_id = runtime.next_msg_id();
-
-    msg.body.msg_id = req_msg_id;
-
-    let (tx, rx) = oneshot::channel::<Message>();
-    let _ = runtime.insert_rpc_sender(req_msg_id, tx).await;
-
-    let req_str = serde_json::to_string(&msg)?;
-    if let Err(err) = runtime.send_raw(req_str.as_str()).await {
-        let _ = runtime.release_rpc_sender(req_msg_id).await;
-        return Err(err);
-    }
-
-    Ok(RPCResult::new(req_msg_id, rx, runtime.clone()))
 }
 
 fn rpc_msg_type(m: Message) -> Result<Message> {


### PR DESCRIPTION
- move `rpc` to `runtime`
- remove unnecessary unstable feature (`async_closure`)
- remove redundant `extern crate core` (not needed for `edition >= 2018`)